### PR TITLE
fixed missing getMiddleware method in Dingo Route class

### DIFF
--- a/src/RouteListCommand.php
+++ b/src/RouteListCommand.php
@@ -100,13 +100,18 @@ class RouteListCommand extends Command
 
 		/** @var Route $route */
 		foreach ($routes as $route) {
-			array_push($rows, [
-				'method'     => implode(' | ', $route->getMethods()),
-				'uri'        => $route->uri(),
-				'name'       => $route->getName(),
-				'action'     => $route->getActionName(),
-				'middleware' => implode(' | ', $route->getMiddleware()),
-			]);
+		    $row = [
+                'method'     => implode(' | ', $route->getMethods()),
+                'uri'        => $route->uri(),
+                'name'       => $route->getName(),
+                'action'     => $route->getActionName(),
+            ];
+
+            $row['middleware'] = method_exists($route, 'getMiddleware')
+                ? implode(' | ', $route->getMiddleware())
+                : 'n/a';
+
+			array_push($rows, $row);
 		}
 
 		return $rows;


### PR DESCRIPTION
It looks like the method *getMiddleware()* in Route class was probably removed from dingo/api and the command fails, so I prepared fix.